### PR TITLE
workaround for feil med kafka-testcontainers

### DIFF
--- a/lib/testing/src/main/kotlin/no/nav/amt/lib/testing/SingletonKafkaProvider.kt
+++ b/lib/testing/src/main/kotlin/no/nav/amt/lib/testing/SingletonKafkaProvider.kt
@@ -23,6 +23,7 @@ object SingletonKafkaProvider {
         log.info("Starting new Kafka Instance...")
 
         kafkaContainer = KafkaContainer(DockerImageName.parse("apache/kafka"))
+            .withEnv("KAFKA_LISTENERS", "PLAINTEXT://:9092,BROKER://:9093,CONTROLLER://:9094")// workaround for https://github.com/testcontainers/testcontainers-java/issues/9506
         kafkaContainer!!.withReuse(reuseConfig.reuse)
         kafkaContainer!!.withLabel("reuse.UUID", reuseConfig.reuseLabel)
         kafkaContainer!!.start()


### PR DESCRIPTION
Når vi bruker nyeste kafkaimage så vil ikke containeren starte. Ser ut til å være en kjent feil: https://github.com/testcontainers/testcontainers-java/issues/9506

Har implementert den foreslåtte workarounden og det ser ut til å virke. 