### PR TITLE
legger til fjerne oppstartsdato

### DIFF
--- a/lib/models/src/main/kotlin/no/nav/amt/lib/models/arrangor/melding/Forslag.kt
+++ b/lib/models/src/main/kotlin/no/nav/amt/lib/models/arrangor/melding/Forslag.kt
@@ -95,9 +95,7 @@ data class Forslag(
         val aarsak: EndringAarsak,
     ) : Endring
 
-    data class FjernOppstartsdato(
-        val fjernet: LocalDateTime,
-    ): Endring
+    data object FjernOppstartsdato : Endring
 
     data class NavAnsatt(
         val id: UUID,

--- a/lib/models/src/main/kotlin/no/nav/amt/lib/models/arrangor/melding/Forslag.kt
+++ b/lib/models/src/main/kotlin/no/nav/amt/lib/models/arrangor/melding/Forslag.kt
@@ -95,6 +95,10 @@ data class Forslag(
         val aarsak: EndringAarsak,
     ) : Endring
 
+    data class FjernOppstartsdato(
+        val fjernet: LocalDateTime,
+    ): Endring
+
     data class NavAnsatt(
         val id: UUID,
         val enhetId: UUID,

--- a/lib/models/src/main/kotlin/no/nav/amt/lib/models/deltaker/DeltakerEndring.kt
+++ b/lib/models/src/main/kotlin/no/nav/amt/lib/models/deltaker/DeltakerEndring.kt
@@ -91,7 +91,6 @@ data class DeltakerEndring(
         ) : Endring()
 
         data class FjernOppstartsdato(
-            val fjernet: LocalDateTime,
             val begrunnelse: String,
         ) : Endring()
     }

--- a/lib/models/src/main/kotlin/no/nav/amt/lib/models/deltaker/DeltakerEndring.kt
+++ b/lib/models/src/main/kotlin/no/nav/amt/lib/models/deltaker/DeltakerEndring.kt
@@ -89,5 +89,10 @@ data class DeltakerEndring(
             val reaktivertDato: LocalDate,
             val begrunnelse: String,
         ) : Endring()
+
+        data class FjernOppstartsdato(
+            val fjernet: LocalDateTime,
+            val begrunnelse: String,
+        ) : Endring()
     }
 }


### PR DESCRIPTION
https://trello.com/c/pr6SFIj6/1968-muligheten-for-%C3%A5-nulle-ut-datoer-og-tilbakef%C3%B8re-brukeren-til-venter-p%C3%A5-oppstart-uten-datoer