### PR TITLE
Legger til enhet navn på ansvarlig tiltakskoordinator

### DIFF
--- a/lib/models/src/main/kotlin/no/nav/amt/lib/models/hendelse/HendelseAnsvarlig.kt
+++ b/lib/models/src/main/kotlin/no/nav/amt/lib/models/hendelse/HendelseAnsvarlig.kt
@@ -14,6 +14,7 @@ sealed interface HendelseAnsvarlig {
         data class Enhet(
             val id: UUID,
             val enhetsnummer: String,
+            val navn: String,
         )
     }
 


### PR DESCRIPTION
https://trello.com/c/gXl0RkTv/2278-enhet-p%C3%A5-brev-blir-satt-til-brukers-oppf%C3%B8lgingsenhet-istedenfor-tiltakskoordinators-enhet