### PR TITLE
Legg til transaksjonsblokk

### DIFF
--- a/lib/utils/build.gradle.kts
+++ b/lib/utils/build.gradle.kts
@@ -11,9 +11,14 @@ dependencies {
     implementation(libs.flyway.core)
     implementation(libs.flyway.postgres)
     implementation(libs.kotliquery)
+    implementation(libs.kotlinx.coroutines)
 
     testImplementation(libs.kotlin.test.junit5)
     testImplementation(libs.junit.jupiter.engine)
+    testImplementation(libs.kotest.assertions.core)
+    testImplementation(libs.kotest.assertions.json)
+    testImplementation(project(":lib:testing"))
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
 }
 
 tasks.named<Test>("test") {

--- a/lib/utils/src/test/kotlin/no/nav/amt/lib/utils/database/DatabaseTest.kt
+++ b/lib/utils/src/test/kotlin/no/nav/amt/lib/utils/database/DatabaseTest.kt
@@ -1,0 +1,79 @@
+package no.nav.amt.lib.utils.database
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+import kotliquery.queryOf
+import no.nav.amt.lib.testing.SingletonPostgres16Container
+import org.junit.jupiter.api.Test
+import org.postgresql.util.PSQLException
+
+class DatabaseTest {
+    init {
+        SingletonPostgres16Container
+    }
+
+    @Test
+    fun `transaksjon rulles tilbake ved feil`() = runTest {
+        val r = DatabaseTestRepository()
+        val n = 1
+
+        try {
+            Database.transaction {
+                r.insert(n)
+                throw IllegalStateException("Skal rulle tilbake insert")
+            }
+        } catch (_: IllegalStateException) {
+            println("Feil etter insert")
+        }
+
+        r.get(n) shouldBe null
+    }
+
+    @Test
+    fun `transaksjon committes uten feil`() = runTest {
+        val r = DatabaseTestRepository()
+        val n = 999
+
+        Database.transaction {
+            r.insert(n)
+        }
+
+        r.get(n) shouldBe n
+    }
+
+    @Test
+    fun `det er ikke mulig å bruke transaksjoner i en transaksjon`() = runTest {
+        val r = DatabaseTestRepository()
+
+        shouldThrow<PSQLException> {
+            Database.transaction {
+                Database.query { s ->
+                    s.transaction {
+                        r.insert(43)
+                    }
+                }
+            }
+        }
+    }
+}
+
+private class DatabaseTestRepository {
+    init {
+        try {
+            Database.query {
+                it.update(queryOf("create table foo (id int primary key)"))
+            }
+        } catch (_: Throwable) {
+        }
+    }
+
+    fun insert(n: Int) = Database.query {
+        it.update(queryOf("insert into foo (id) values (?)", n))
+    }
+
+    fun get(n: Int) = Database.query {
+        val q = queryOf("select * from foo where id = ?", n).map { r -> r.int("id") }.asSingle
+        it.run(q)
+    }
+}

--- a/lib/utils/src/test/kotlin/no/nav/amt/lib/utils/database/DatabaseTransactionalSessionTest.kt
+++ b/lib/utils/src/test/kotlin/no/nav/amt/lib/utils/database/DatabaseTransactionalSessionTest.kt
@@ -1,0 +1,69 @@
+package no.nav.amt.lib.utils.database
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import kotliquery.TransactionalSession
+import no.nav.amt.lib.testing.SingletonPostgres16Container
+import org.junit.jupiter.api.Test
+
+class DatabaseTransactionalSessionTest {
+    init {
+        SingletonPostgres16Container
+    }
+
+    @Test
+    fun `transactionalSession skal være null uten en transaksjonsblokk`() {
+        Database.transactionalSession shouldBe null
+    }
+
+    @Test
+    fun `transactionalSession skal ikke være null i en transaksjonsblokk og fjernes etter blokken`() = runTest {
+        var insideSession: TransactionalSession?
+        Database.transaction {
+            insideSession = Database.transactionalSession
+            insideSession shouldNotBe null
+        }
+        Database.transactionalSession shouldBe null
+    }
+
+    @Test
+    fun `transaksjoner skal ikke gjenbruke session`() = runTest {
+        var firstSession: TransactionalSession? = null
+        var secondSession: TransactionalSession? = null
+
+        Database.transaction {
+            firstSession = Database.transactionalSession
+        }
+        Database.transaction {
+            secondSession = Database.transactionalSession
+        }
+
+        firstSession shouldNotBe null
+        secondSession shouldNotBe null
+        firstSession shouldNotBe secondSession
+    }
+
+    @Test
+    fun `sessions skal ikke gjenbrukes på tvers av coroutines og skal lukkes etter ferdig bruk`(): Unit = runBlocking {
+        val sessions = mutableListOf<TransactionalSession?>()
+        val maxConnectionPoolSize = 10
+
+        val jobs = List(maxConnectionPoolSize + 1) {
+            launch {
+                delay(1000)
+                Database.transaction {
+                    sessions.add(Database.transactionalSession)
+                }
+            }
+        }
+        jobs.joinAll()
+
+        sessions.forEach { it shouldNotBe null }
+        sessions.toSet().size shouldBe maxConnectionPoolSize + 1
+    }
+}


### PR DESCRIPTION
Denne funksjonen gjør det mulig å utføre databaseoperasjoner innenfor
en transaksjon i coroutine-miljøer. Den sørger for korrekt isolering
ved hjelp av `ThreadLocal.asContextElement` og forhindrer nøstede
transaksjoner.

Eksempel på bruk:
```kotlin
    suspend fun lagreDeltaker(deltaker: Deltaker) {
        Database.transaction {
            deltakerRepository.upsert(deltaker)
            deltakerStatusRepository.upsert(deltaker.status)
        }
    }
```

Funksjonen kan trygt brukes parallelt i flere coroutines uten at
transaksjoner eller sessions lekker mellom dem.
