### PR TITLE
Bump dependencies - 20250617133422

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ hikari-version = "6.3.0"
 kotliquery-version = "1.9.1"
 postgres-version = "42.7.7"
 kotlin-version = "2.1.21"
-jackson-version = "2.19.0"
+jackson-version = "2.19.1"
 
 [libraries]
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit-jupiter-engine" }


### PR DESCRIPTION
This PR includes the following Dependabot updates rebased into the bump-deps-20250617133422 branch:

## Successfully Rebased PRs
- [Bump jackson-version from 2.19.0 to 2.19.1](https://github.com/navikt/amt-lib/pull/171)
- [Bump org.postgresql:postgresql from 42.7.6 to 42.7.7](https://github.com/navikt/amt-lib/pull/169)
- [Bump org.junit.jupiter:junit-jupiter-engine from 5.12.2 to 5.13.1](https://github.com/navikt/amt-lib/pull/168)
- [Bump flyway-version from 11.8.2 to 11.9.1](https://github.com/navikt/amt-lib/pull/167)
- [Bump testcontainers-version from 1.21.0 to 1.21.1](https://github.com/navikt/amt-lib/pull/163)


