### PR TITLE
Gjør det mulig å kjøre koordinert shutdown av pod

### DIFF
--- a/lib/kafka/src/main/kotlin/no/nav/amt/lib/kafka/Consumer.kt
+++ b/lib/kafka/src/main/kotlin/no/nav/amt/lib/kafka/Consumer.kt
@@ -4,4 +4,6 @@ interface Consumer<K, V> {
     suspend fun consume(key: K, value: V)
 
     fun start()
+
+    suspend fun close()
 }


### PR DESCRIPTION
Må ha tilgang til close for at applikasjonen som bruker lib skal kunne lukke databasen etter at consumeren er ferdig

Tror at det da er hensiktsmessig å fjerne shutdown hooken som er definert her i lib, men tror det går fint at den er her enn så lenge fordi det første som skal skje er uansett at konsumenten lukkes så det skader ikke om den hooken kjører ferdig først 

https://trello.com/c/3fiag15H/2355-h%C3%A5ndtering-av-pod-shutdown
