### PR TITLE
Sletter shutdown hook fordi shutdown må koordineres i appen som bruker consumeren

### DIFF
--- a/lib/kafka/src/main/kotlin/no/nav/amt/lib/kafka/ManagedKafkaConsumer.kt
+++ b/lib/kafka/src/main/kotlin/no/nav/amt/lib/kafka/ManagedKafkaConsumer.kt
@@ -6,7 +6,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.runBlocking
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.consumer.ConsumerRecords
@@ -32,15 +31,6 @@ class ManagedKafkaConsumer<K, V>(
 
     val status: ConsumerStatus = ConsumerStatus()
     private lateinit var runState: Deferred<Unit>
-
-    init {
-        Runtime.getRuntime().addShutdownHook(
-            Thread {
-                log.info("Received shutdown signal for Kafka consumer $topic")
-                runBlocking { close() }
-            },
-        )
-    }
 
     fun start() {
         log.info("Starting consumer for topic: $topic")


### PR DESCRIPTION
for å sørge for at ting blir avsluttet på riktig måte når podden skal ned

Merges når amt-distribusjon er "ledig" sånn at jeg får koda inn ny shutdown håndtering der samtidig