### PR TITLE
Lagt til msg til log.error

### DIFF
--- a/lib/kafka/src/main/kotlin/no/nav/amt/lib/kafka/ManagedKafkaConsumer.kt
+++ b/lib/kafka/src/main/kotlin/no/nav/amt/lib/kafka/ManagedKafkaConsumer.kt
@@ -78,7 +78,7 @@ class ManagedKafkaConsumer<K, V>(
         if (status.isFailure) {
             log.info(
                 "Consumer status for topic $topic is failure, " +
-                        "delaying ${status.backoffDuration}ms before retrying",
+                    "delaying ${status.backoffDuration}ms before retrying",
             )
             delay(status.backoffDuration)
         }
@@ -102,7 +102,7 @@ class ManagedKafkaConsumer<K, V>(
                 status.success()
             }
         } catch (t: Throwable) {
-            log.error(t.message, t)
+            log.error("Error while polling Kafka records: ${t.message}", t)
             status.failure()
         } finally {
             commitOffsets(consumer)
@@ -141,17 +141,17 @@ class ManagedKafkaConsumer<K, V>(
             consume(record.key(), record.value())
             log.info(
                 "Consumed record for " +
-                        "topic=${record.topic()} " +
-                        "key=${record.key()} " +
-                        "partition=${record.partition()} " +
-                        "offset=${record.offset()}",
-            )
-        } catch (t: Throwable) {
-            val msg = "Failed to consume record for " +
                     "topic=${record.topic()} " +
                     "key=${record.key()} " +
                     "partition=${record.partition()} " +
-                    "offset=${record.offset()}"
+                    "offset=${record.offset()}",
+            )
+        } catch (t: Throwable) {
+            val msg = "Failed to consume record for " +
+                "topic=${record.topic()} " +
+                "key=${record.key()} " +
+                "partition=${record.partition()} " +
+                "offset=${record.offset()}"
             throw ConsumerProcessingException(msg, t)
         }
     }


### PR DESCRIPTION
Et forsøk på å fikse log-entries som mangler log-level.

Hypotesen er at denne linjen gir log-entries uten log-level når t.message = null
`log.error(t.message, t)`

Har derfor lagt til error message slik det er gjort ellers i omkringliggende kode:
`log.error("Error while polling Kafka records: ${t.message}", t)`

Har gått gjennom øvrige forekomster av log.error/warn i repoet, alle disse var OK.