### PR TITLE
Renamer Deltaker for å gjøre det tydeligere at denne brukes til kafka

### DIFF
--- a/lib/models/src/main/kotlin/no/nav/amt/lib/models/deltaker/DeltakerKafkaPayload.kt
+++ b/lib/models/src/main/kotlin/no/nav/amt/lib/models/deltaker/DeltakerKafkaPayload.kt
@@ -10,7 +10,7 @@ import java.util.UUID
 /*
     Deltaker core modell som brukes til deltaker-v2
  */
-data class Deltaker(
+data class DeltakerKafkaPayload(
     val id: UUID,
     val deltakerliste: Deltakerliste,
     val personalia: Personalia,
@@ -27,7 +27,7 @@ data class Deltaker(
     val historikk: List<DeltakerHistorikk>?,
     val vurderingerFraArrangor: List<Vurdering>?,
     val erManueltDeltMedArrangor: Boolean = false,
-    val sisteEndring: SisteEndring,
+    val sisteEndring: SisteEndring?,
 
     /*
         Felter som bør deprecates og flyttes inn i relevante strukturer:
@@ -48,9 +48,11 @@ data class Deltaker(
     val sistEndretAv: UUID?,
     // @Deprecated("Bruk sisteEndring.enhet")
     val sistEndretAvEnhet: UUID?,
+    val forcedUpdate: Boolean? = false,
 )
 
-data class DeltakerStatusDto( //Kan ikke bytte til DeltakerStatus siden denne har en annen struktur på aarsak
+data class DeltakerStatusDto(
+    //Kan ikke bytte til DeltakerStatus siden denne har en annen struktur på aarsak
     val id: UUID?,
     val type: DeltakerStatus.Type,
     val aarsak: DeltakerStatus.Aarsak.Type?,
@@ -60,7 +62,7 @@ data class DeltakerStatusDto( //Kan ikke bytte til DeltakerStatus siden denne ha
 )
 
 data class SisteEndring(
-    val utfortAv: NavAnsatt,
-    val enhet: String,
+    val utfortAvNavAnsattId: UUID,
+    val navEnhetId: UUID?,
     val timestamp: LocalDateTime,
 )

--- a/lib/models/src/main/kotlin/no/nav/amt/lib/models/deltaker/Deltakerliste.kt
+++ b/lib/models/src/main/kotlin/no/nav/amt/lib/models/deltaker/Deltakerliste.kt
@@ -8,7 +8,6 @@ import java.util.UUID
 data class Deltakerliste(
     val id: UUID,
     val navn: String,
-    val arrangor: Arrangor,
     val tiltak: Tiltak,
     val startdato: LocalDate? = null,
     val sluttdato: LocalDate? = null,

--- a/lib/models/src/main/kotlin/no/nav/amt/lib/models/deltakerliste/tiltakstype/Tiltak.kt
+++ b/lib/models/src/main/kotlin/no/nav/amt/lib/models/deltakerliste/tiltakstype/Tiltak.kt
@@ -2,7 +2,6 @@ package no.nav.amt.lib.models.deltakerliste.tiltakstype
 
 data class Tiltak(
     val navn: String,
-    val type: ArenaKode,
-    val ledetekst: String?,
+    val arenaKode: ArenaKode,
     val tiltakskode: Tiltakskode,
 )


### PR DESCRIPTION
fordi det kan skape forvirring i applikasjoner som allerede har en intern Deltaker modell(selv om denne kanskje kan erstattes av dette objektet, men dette blir for tidkrevende nå).

Fjerner felter som uansett ikke blir brukt av noen (til kafka kommunikasjon), disse kan man vurdere å legge til når behovet oppstår

https://trello.com/c/K8jHfvjS/2435-stoppe-data-fra-%C3%A5-dukke-opp-i-tiltaksarrang%C3%B8rs-deltakeroversikt